### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 ﻿# NMRS-POC-OMODS
-the first set of modules that is loded into the POC NMRS
+These sets of modules are required for the full functionality of NMRS POC but the modules are not bundled with the NMRS-POC war file.
+The  modules are:
+
+1. cdrsync-1.1.3-update.omod
+2. covidtbintegrator-2.0.0-SNAPSHOT.omod
+3. customuinmrs-1.0.2.omod (The size of this module exceeded gihub's limit, please click [here](https://ihvnigeria-my.sharepoint.com/:u:/g/personal/auji_ihvnigeria_org/EXmQALAwOJRHrLkCYuACH30BTMK3nYHS3FIeXFBJq6KG_A?e=TxriKc) to download it)
+4. dataquality-1.0.3.omod
+5. fpverification-1.0.1-SNAPSHOT.omod
+6. jasperreport-2.0.0.omod
+7. limsemrops-1.0.8.omod
+8. nigeriaemr-1.6.5.0-SNAPSHOT.omod
+9. nmrsmetadata-poc-1.0.3.1.omod
+10. nmrsreports-1.0.3-SNAPSHOT.omod
+11. openhmis.backboneforms-3.0.0.omod
+12. openhmis.commons-4.0.0.omod
+13. openhmis.inventory-4.0.3.5-SNAPSHOT.omod
+14. patientqueueing-1.0.0.omod
+
+Note that due to the dynamic nature of program reporting requirments and constant system review, these modules are subject to changes.
+The modules should be downloaded and copied to the .OpenMRS/modules folder after a new installation.
+Remember to restart the tomcat after copying the modules into the folder for the changes to be effective.


### PR DESCRIPTION
﻿# NMRS-POC-OMODS
These sets of modules are required for the full functionality of NMRS POC but the modules are not bundled with the NMRS-POC war file.
The  modules are:

1. cdrsync-1.1.3-update.omod
2. covidtbintegrator-2.0.0-SNAPSHOT.omod
3. customuinmrs-1.0.2.omod (The size of this module exceeded gihub's limit, please click [here](https://ihvnigeria-my.sharepoint.com/:u:/g/personal/auji_ihvnigeria_org/EXmQALAwOJRHrLkCYuACH30BTMK3nYHS3FIeXFBJq6KG_A?e=TxriKc) to download it)
4. dataquality-1.0.3.omod
5. fpverification-1.0.1-SNAPSHOT.omod
6. jasperreport-2.0.0.omod
7. limsemrops-1.0.8.omod
8. nigeriaemr-1.6.5.0-SNAPSHOT.omod
9. nmrsmetadata-poc-1.0.3.1.omod
10. nmrsreports-1.0.3-SNAPSHOT.omod
11. openhmis.backboneforms-3.0.0.omod
12. openhmis.commons-4.0.0.omod
13. openhmis.inventory-4.0.3.5-SNAPSHOT.omod
14. patientqueueing-1.0.0.omod

Note that due to the dynamic nature of program reporting requirments and constant system review, these modules are subject to changes.
The modules should be downloaded and copied to the .OpenMRS/modules folder after a new installation.
Remember to restart the tomcat after copying the modules into the folder for the changes to be effective.